### PR TITLE
feat: upload benchmark duration under PR comment

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,10 @@ jobs:
   go:
     name: Go ${{ matrix.task }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
     strategy:
       matrix:
         task: [fmt, test, benchmark]
@@ -42,8 +46,17 @@ jobs:
         if: matrix.task == 'benchmark'
         run: bash ./benchmarks/take_benchmarks.sh
       # Upload benchmark artifacts
-      - uses: actions/upload-artifact@v4
+      - name: Upload benchmark artifacts
+        if: matrix.task == 'benchmark'
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-report
           path: benchmarks/*.svg
           retention-days: 30
+      # Comment benchmark duration as comment under PR
+      - name: Upload benchmark duration as comment
+        if: matrix.task == 'benchmark'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          filePath: benchmark_duration.txt

--- a/benchmarks/take_benchmarks.sh
+++ b/benchmarks/take_benchmarks.sh
@@ -13,7 +13,7 @@ for benchmark in $benchmarks; do
     mem_profile="benchmarks/${benchmark_date}_${benchmark}_mem.prof"
 
     # Run the benchmark with CPU profiling enabled
-    go test -run=^$ -bench "^$benchmark$" github.com/farbodahm/streame/benchmarks -count=10 -cpuprofile="$cpu_profile" -memprofile="$mem_profile"
+    go test -run=^$ -bench "^$benchmark$" github.com/farbodahm/streame/benchmarks -count=1 -cpuprofile="$cpu_profile" -memprofile="$mem_profile"
 
     echo -e "$benchmark CPU Result:\n"
     go tool pprof -text "$cpu_profile"
@@ -22,4 +22,8 @@ for benchmark in $benchmarks; do
 
     go tool pprof -svg "$cpu_profile" > "$cpu_profile.svg"
     go tool pprof -svg "$mem_profile" > "$mem_profile.svg"
+
+    # Write benchmark duration on a file to be uploaded on PR as comment
+    duration=$(go tool pprof -text test.pprof | grep -oE 'Duration: [0-9]+(\.[0-9]+)?.?' | grep -oE '[0-9]+(\.[0-9]+)?.?')
+    echo -e "$benchmark Duration: $duration" >> benchmark_duration.txt
 done

--- a/benchmarks/take_benchmarks.sh
+++ b/benchmarks/take_benchmarks.sh
@@ -24,6 +24,6 @@ for benchmark in $benchmarks; do
     go tool pprof -svg "$mem_profile" > "$mem_profile.svg"
 
     # Write benchmark duration on a file to be uploaded on PR as comment
-    duration=$(go tool pprof -text test.pprof | grep -oE 'Duration: [0-9]+(\.[0-9]+)?.?' | grep -oE '[0-9]+(\.[0-9]+)?.?')
-    echo -e "$benchmark Duration: $duration" >> benchmark_duration.txt
+    duration=$(go tool pprof -text "$cpu_profile" | grep -oE 'Duration: [0-9]+(\.[0-9]+)?.?' | grep -oE '[0-9]+(\.[0-9]+)?.?')
+    echo -e "- $benchmark Duration: $duration :hourglass_flowing_sand:" >> benchmark_duration.txt
 done


### PR DESCRIPTION
For a better Devex and to decrease the lead time to understand the impact of changes, this PR sends benchmark execution time as a comment on the opened PR.

Closes #14