### PR TITLE
fix: no need to comment benchmark on main branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,7 +55,7 @@ jobs:
           retention-days: 30
       # Comment benchmark duration as comment under PR
       - name: Upload benchmark duration as comment
-        if: matrix.task == 'benchmark'
+        if: github.event_name == 'pull_request' && matrix.task == 'benchmark'
         uses: thollander/actions-comment-pull-request@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR #17 introduced a bug while running CI on `main` branch which was related to commenting benchmark result on CI.
This PR disables commenting on `main` branch.