### PR TITLE
feat: add schema validator functionality

### DIFF
--- a/benchmarks/filter_benchmark_test.go
+++ b/benchmarks/filter_benchmark_test.go
@@ -39,7 +39,7 @@ func heavy_filter_stages(number_of_stages int, number_of_records int) {
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	result_df.Execute(ctx)
+	go result_df.Execute(ctx)
 
 	for i := 0; i < number_of_records; i++ {
 		<-output

--- a/benchmarks/filter_benchmark_test.go
+++ b/benchmarks/filter_benchmark_test.go
@@ -17,12 +17,7 @@ func heavy_filter_stages(number_of_stages int, number_of_records int) {
 	output := make(chan Record)
 	errors := make(chan error)
 
-	sdf := core.StreamDataFrame{
-		SourceStream: input,
-		OutputStream: output,
-		ErrorStream:  errors,
-		Stages:       []core.Stage{},
-	}
+	sdf := core.NewStreamDataFrame(input, output, errors, utils.HeavyRecordSchema())
 
 	// Create stages
 	filter := functions.Filter{

--- a/benchmarks/schema_validation_benchmark_test.go
+++ b/benchmarks/schema_validation_benchmark_test.go
@@ -1,0 +1,40 @@
+package benchmarks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/farbodahm/streame/pkg/core"
+	. "github.com/farbodahm/streame/pkg/types"
+	"github.com/farbodahm/streame/pkg/utils"
+)
+
+// heavy_schema_validation_stages creates lots of heavy structs
+// to benchmark performance of schema validation
+func heavy_schema_validation_stages(number_of_records int) {
+	input := make(chan Record)
+	output := make(chan Record)
+	errors := make(chan error)
+
+	sdf := core.NewStreamDataFrame(input, output, errors, utils.HeavyRecordSchema())
+
+	go func() {
+		for i := 0; i < number_of_records; i++ {
+			input <- utils.NewHeavyRecord(100)
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sdf.Execute(ctx)
+
+	for i := 0; i < number_of_records; i++ {
+		<-output
+	}
+	cancel()
+}
+
+func BenchmarkSchemaValidation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		heavy_schema_validation_stages(2000)
+	}
+}

--- a/benchmarks/schema_validation_benchmark_test.go
+++ b/benchmarks/schema_validation_benchmark_test.go
@@ -25,7 +25,7 @@ func heavy_schema_validation_stages(number_of_records int) {
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sdf.Execute(ctx)
+	go sdf.Execute(ctx)
 
 	for i := 0; i < number_of_records; i++ {
 		<-output

--- a/pkg/core/stream_dataframe.go
+++ b/pkg/core/stream_dataframe.go
@@ -18,6 +18,25 @@ type StreamDataFrame struct {
 	Schema       types.Schema
 }
 
+// NewStreamDataFrame creates a new StreamDataFrame with the given options
+func NewStreamDataFrame(
+	sourceStream chan (types.Record),
+	outputStream chan (types.Record),
+	errorStream chan error,
+	schema types.Schema) StreamDataFrame {
+	sdf := StreamDataFrame{
+		SourceStream: sourceStream,
+		OutputStream: outputStream,
+		ErrorStream:  errorStream,
+		Stages:       []Stage{},
+		Schema:       schema,
+	}
+
+	sdf.validateSchema()
+	return sdf
+}
+
+// Filter applies filter function to each record of the DataFrame
 func (sdf *StreamDataFrame) Filter(filter functions.Filter) DataFrame {
 	executor := func(ctx context.Context, data types.Record) ([]types.Record, error) {
 		// TODO: Decide on passing by reference here
@@ -31,6 +50,25 @@ func (sdf *StreamDataFrame) Filter(filter functions.Filter) DataFrame {
 	return sdf
 }
 
+// validateSchema validates that each individual record follows the schema of the DataFrame
+func (sdf *StreamDataFrame) validateSchema() DataFrame {
+	executor := func(ctx context.Context, data types.Record) ([]types.Record, error) {
+		err := functions.ValidateSchema(sdf.Schema, data)
+
+		if err != nil {
+			panic(err)
+		}
+
+		return []types.Record{data}, nil
+	}
+
+	sdf.addToStages(executor)
+	return sdf
+}
+
+// addToStages adds a new stage to the DataFrame.
+// it wires the output of the previous stage to the input of this stage
+// and the output of this stage to the output of the DataFrame.
 func (sdf *StreamDataFrame) addToStages(executor StageExecutor) {
 	var input_stream chan types.Record
 
@@ -58,6 +96,8 @@ func (sdf *StreamDataFrame) addToStages(executor StageExecutor) {
 	sdf.Stages = append(sdf.Stages, stage)
 }
 
+// Execute starts the data processing.
+// It simply runs all of the stages.
 func (sdf *StreamDataFrame) Execute(ctx context.Context) error {
 	if len(sdf.Stages) == 0 {
 		return errors.New("no stages are created")

--- a/pkg/core/stream_dataframe_test.go
+++ b/pkg/core/stream_dataframe_test.go
@@ -4,46 +4,43 @@ import (
 	"context"
 	"testing"
 
-	"github.com/farbodahm/streame/pkg/types"
+	. "github.com/farbodahm/streame/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSreamDataFrame_AddStage_FirstStage(t *testing.T) {
-	input := make(chan types.Record)
-	output := make(chan types.Record)
+	input := make(chan Record)
+	output := make(chan Record)
 	errors := make(chan error)
 
-	sdf := StreamDataFrame{
-		SourceStream: input,
-		OutputStream: output,
-		ErrorStream:  errors,
-		Stages:       []Stage{},
+	schema := Schema{
+		Columns: Fields{},
 	}
-	executor := func(ctx context.Context, data types.Record) ([]types.Record, error) {
+	sdf := NewStreamDataFrame(input, output, errors, schema)
+	executor := func(ctx context.Context, data Record) ([]Record, error) {
 		return nil, nil
 	}
 
 	sdf.addToStages(executor)
 
 	// Assertions
-	assert.Equal(t, 1, len(sdf.Stages))
+	// First stage is schema validator, so the first added stage by user will be second stage
+	assert.Equal(t, 2, len(sdf.Stages))
 	assert.Equal(t, input, sdf.Stages[0].Input)
-	assert.Equal(t, sdf.Stages[0].Output, sdf.OutputStream)
+	assert.Equal(t, sdf.Stages[1].Output, sdf.OutputStream)
 	assert.Equal(t, sdf.Stages[0].Error, sdf.ErrorStream)
 }
 
 func TestSreamDataFrame_AddStage_ChainStages(t *testing.T) {
-	input := make(chan types.Record)
-	output := make(chan types.Record)
+	input := make(chan Record)
+	output := make(chan Record)
 	errors := make(chan error)
 
-	sdf := StreamDataFrame{
-		SourceStream: input,
-		OutputStream: output,
-		ErrorStream:  errors,
-		Stages:       []Stage{},
+	schema := Schema{
+		Columns: Fields{},
 	}
-	executor := func(ctx context.Context, data types.Record) ([]types.Record, error) {
+	sdf := NewStreamDataFrame(input, output, errors, schema)
+	executor := func(ctx context.Context, data Record) ([]Record, error) {
 		return nil, nil
 	}
 
@@ -51,17 +48,18 @@ func TestSreamDataFrame_AddStage_ChainStages(t *testing.T) {
 	sdf.addToStages(executor)
 
 	// Assertions
-	assert.Equal(t, 2, len(sdf.Stages))
+	// First stage is schema validator
+	assert.Equal(t, 3, len(sdf.Stages))
 	assert.Equal(t, input, sdf.Stages[0].Input)
 	assert.Equal(t, sdf.Stages[0].Output, sdf.Stages[1].Input)
-	assert.Equal(t, sdf.Stages[1].Output, sdf.OutputStream)
+	assert.Equal(t, sdf.Stages[2].Output, sdf.OutputStream)
 	assert.Equal(t, sdf.Stages[0].Error, sdf.ErrorStream)
 	assert.Equal(t, sdf.Stages[1].Error, sdf.ErrorStream)
 }
 
 func TestSreamDataFrame_Execute_ErrorIfNoStagesDefined(t *testing.T) {
-	input := make(chan types.Record)
-	output := make(chan types.Record)
+	input := make(chan Record)
+	output := make(chan Record)
 	errors := make(chan error)
 
 	sdf := StreamDataFrame{

--- a/pkg/functions/filter_test.go
+++ b/pkg/functions/filter_test.go
@@ -90,12 +90,13 @@ func TestFilter_WithDataFrame_AcceptRelatedRecord(t *testing.T) {
 	output := make(chan Record)
 	errors := make(chan error)
 
-	sdf := core.StreamDataFrame{
-		SourceStream: input,
-		OutputStream: output,
-		ErrorStream:  errors,
-		Stages:       []core.Stage{},
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+		},
 	}
+	sdf := core.NewStreamDataFrame(input, output, errors, schema)
 
 	// Logic to test
 	result_df := sdf.Filter(functions.Filter{
@@ -144,12 +145,14 @@ func TestFilter_WithChainedDataFrame_AcceptRelatedRecord(t *testing.T) {
 	output := make(chan Record)
 	errors := make(chan error)
 
-	sdf := core.StreamDataFrame{
-		SourceStream: input,
-		OutputStream: output,
-		ErrorStream:  errors,
-		Stages:       []core.Stage{},
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"email":      StringType,
+		},
 	}
+	sdf := core.NewStreamDataFrame(input, output, errors, schema)
 
 	// Logic to test
 	result_df := sdf.Filter(functions.Filter{

--- a/pkg/functions/filter_test.go
+++ b/pkg/functions/filter_test.go
@@ -131,9 +131,11 @@ func TestFilter_WithDataFrame_AcceptRelatedRecord(t *testing.T) {
 		}
 	}()
 
-	result_df.Execute(context.Background())
+	ctx := context.Background()
+	go result_df.Execute(ctx)
 
 	// Assertions
+	ctx.Done()
 	result := <-output
 	assert.Equal(t, result, accepted_record)
 	assert.Equal(t, 0, len(output))
@@ -198,9 +200,11 @@ func TestFilter_WithChainedDataFrame_AcceptRelatedRecord(t *testing.T) {
 		}
 	}()
 
-	result_df.Execute(context.Background())
+	ctx := context.Background()
+	go result_df.Execute(ctx)
 
 	// Assertions
+	ctx.Done()
 	result := <-output
 	assert.Equal(t, result, accepted_record)
 	assert.Equal(t, 0, len(output))

--- a/pkg/functions/schema_validator.go
+++ b/pkg/functions/schema_validator.go
@@ -1,0 +1,29 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/farbodahm/streame/pkg/types"
+)
+
+var ErrSchemaLengthMismatch = "dataframe schema and record schema length mismatch: expected %d, got %d"
+var ErrColumnNotFound = "column '%s' not found"
+var ErrColumnTypeMismatch = "column type mismatch for column '%s': expected %s, got %s"
+
+// ValidateSchema validates the record against the schema
+func ValidateSchema(schema types.Schema, record types.Record) error {
+	if len(schema.Columns) != len(record.Data) {
+		return fmt.Errorf(ErrSchemaLengthMismatch, len(schema.Columns), len(record.Data))
+	}
+
+	for k, v := range schema.Columns {
+		if _, ok := record.Data[k]; !ok {
+			return fmt.Errorf(ErrColumnNotFound, k)
+		}
+		if v != record.Data[k].Type() {
+			return fmt.Errorf(ErrColumnTypeMismatch, k, v, record.Data[k].Type())
+		}
+	}
+
+	return nil
+}

--- a/pkg/functions/schema_validator_test.go
+++ b/pkg/functions/schema_validator_test.go
@@ -1,9 +1,11 @@
 package functions_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/farbodahm/streame/pkg/core"
 	"github.com/farbodahm/streame/pkg/functions"
 	. "github.com/farbodahm/streame/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -117,4 +119,102 @@ func TestSchemaValidator_ColumnTypeMisMatch_RejectRecord(t *testing.T) {
 	expected_err := fmt.Sprintf(functions.ErrColumnTypeMismatch, "age", IntType, StringType)
 
 	assert.EqualError(t, actual_err, expected_err)
+}
+
+func TestSreamDataFrame_SchemaValidation_AcceptRecordFollowSchema(t *testing.T) {
+	input := make(chan Record)
+	output := make(chan Record)
+	errors := make(chan error)
+
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"age":        IntType,
+		},
+	}
+	sdf := core.NewStreamDataFrame(input, output, errors, schema)
+
+	// Generate sample data
+	record_1 := Record{
+		Key: "key1",
+		Data: ValueMap{
+			"first_name": String{Val: "random_name"},
+			"last_name":  String{Val: "random_lastname"},
+			"age":        Integer{Val: 10},
+		},
+	}
+	record_2 := Record{
+		Key: "key2",
+		Data: ValueMap{
+			"first_name": String{Val: "foobar"},
+			"last_name":  String{Val: "random_lastname"},
+			"age":        Integer{Val: 20},
+		},
+	}
+	go func() {
+		input <- record_1
+		input <- record_2
+	}()
+
+	ctx := context.Background()
+	go sdf.Execute(ctx)
+
+	ctx.Done()
+	result_1 := <-output
+	result_2 := <-output
+
+	// Assertions
+	assert.Equal(t, result_1.Key, "key1")
+	assert.Equal(t, result_2.Key, "key2")
+	assert.Equal(t, 0, len(errors))
+	assert.Equal(t, 0, len(output))
+	assert.Equal(t, 0, len(input))
+}
+
+func TestSreamDataFrame_SchemaValidation_PanicIfRecordDoesntFollowSchema(t *testing.T) {
+	input := make(chan Record)
+	output := make(chan Record)
+	errors := make(chan error)
+
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"age":        IntType,
+		},
+	}
+	sdf := core.NewStreamDataFrame(input, output, errors, schema)
+
+	// Generate sample data
+	faulty_record := Record{
+		Key: "key2",
+		Data: ValueMap{
+			"first_name": String{Val: "foobar"},
+			"last_name":  String{Val: "random_lastname"},
+		},
+	}
+	go func() {
+		input <- Record{
+			Key: "key1",
+			Data: ValueMap{
+				"first_name": String{Val: "random_name"},
+				"last_name":  String{Val: "random_lastname"},
+				"age":        Integer{Val: 10},
+			},
+		}
+		input <- faulty_record
+
+	}()
+	go func() {
+		<-output
+		<-output
+	}()
+
+	assert.Panics(t, func() {
+		sdf.Execute(context.Background())
+	})
+	assert.Equal(t, 0, len(errors))
+	assert.Equal(t, 0, len(output))
+	assert.Equal(t, 0, len(input))
 }

--- a/pkg/functions/schema_validator_test.go
+++ b/pkg/functions/schema_validator_test.go
@@ -1,0 +1,120 @@
+package functions_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/farbodahm/streame/pkg/functions"
+	. "github.com/farbodahm/streame/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchemaValidator_CorrectSchema_AcceptRecord(t *testing.T) {
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"age":        IntType,
+		},
+	}
+	record := Record{
+		Key: "key1",
+		Data: ValueMap{
+			"first_name": String{Val: "foobar"},
+			"last_name":  String{Val: "random_lastname"},
+			"age":        Integer{Val: 23},
+		},
+	}
+
+	err := functions.ValidateSchema(schema, record)
+
+	assert.Nil(t, err)
+}
+
+func TestSchemaValidator_SchemaHasMoreColumns_RejectRecord(t *testing.T) {
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"age":        IntType,
+		},
+	}
+	record := Record{
+		Key: "key1",
+		Data: ValueMap{
+			"first_name": String{Val: "foobar"},
+			"last_name":  String{Val: "random_lastname"},
+		},
+	}
+
+	actual_err := functions.ValidateSchema(schema, record)
+	expected_err := fmt.Sprintf(functions.ErrSchemaLengthMismatch, len(schema.Columns), len(record.Data))
+
+	assert.EqualError(t, actual_err, expected_err)
+}
+
+func TestSchemaValidator_RecordHasLessColumns_RejectRecord(t *testing.T) {
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+		},
+	}
+	record := Record{
+		Key: "key1",
+		Data: ValueMap{
+			"first_name": String{Val: "foobar"},
+			"last_name":  String{Val: "random_lastname"},
+			"age":        Integer{Val: 23},
+		},
+	}
+
+	actual_err := functions.ValidateSchema(schema, record)
+	expected_err := fmt.Sprintf(functions.ErrSchemaLengthMismatch, len(schema.Columns), len(record.Data))
+
+	assert.EqualError(t, actual_err, expected_err)
+}
+
+func TestSchemaValidator_ColumnNotExistInRecord_RejectRecord(t *testing.T) {
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+		},
+	}
+	record := Record{
+		Key: "key1",
+		Data: ValueMap{
+			"first_name": String{Val: "foobar"},
+			"age":        Integer{Val: 23},
+		},
+	}
+
+	actual_err := functions.ValidateSchema(schema, record)
+	expected_err := fmt.Sprintf(functions.ErrColumnNotFound, "last_name")
+
+	assert.EqualError(t, actual_err, expected_err)
+}
+
+func TestSchemaValidator_ColumnTypeMisMatch_RejectRecord(t *testing.T) {
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"age":        IntType,
+		},
+	}
+	record := Record{
+		Key: "key1",
+		Data: ValueMap{
+			"first_name": String{Val: "foobar"},
+			"last_name":  String{Val: "random_lastname"},
+			"age":        String{Val: "23"},
+		},
+	}
+
+	actual_err := functions.ValidateSchema(schema, record)
+	expected_err := fmt.Sprintf(functions.ErrColumnTypeMismatch, "age", IntType, StringType)
+
+	assert.EqualError(t, actual_err, expected_err)
+}

--- a/pkg/utils/test_utils.go
+++ b/pkg/utils/test_utils.go
@@ -19,6 +19,34 @@ func GenerateRandomString(length int) string {
 	return string(b)
 }
 
+// HeavyRecordSchema returns schema for the HeavyRecord
+func HeavyRecordSchema() Schema {
+	return Schema{
+		Columns: Fields{
+			"field_1":  StringType,
+			"field_2":  StringType,
+			"field_3":  StringType,
+			"field_4":  StringType,
+			"field_5":  StringType,
+			"field_6":  StringType,
+			"field_7":  StringType,
+			"field_8":  StringType,
+			"field_9":  StringType,
+			"field_10": StringType,
+			"field_11": StringType,
+			"field_12": StringType,
+			"field_13": StringType,
+			"field_14": StringType,
+			"field_15": StringType,
+			"field_16": StringType,
+			"field_17": StringType,
+			"field_18": StringType,
+			"field_19": StringType,
+			"field_20": StringType,
+		},
+	}
+}
+
 // NewHeavyRecord creates a new heavy Record with random string values
 // with given length.
 // You can use this for benchmark tests.


### PR DESCRIPTION
This PR:

- Adds individual functionality for validating schema of a record
  - Add unit tests
- Run the schema validator functionality in the first stage to validate each individual record against data frame schema
  - Update tests accordingly

Closes #16 