### PR TITLE
feat: add column rename function

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ section of each CI pipeline run.
 - [x] Filter
 - [x] Select
 - [x] Add static column
+- [x] Add column rename
 - [ ] Join
 - [ ] Aggregation
 

--- a/benchmarks/rename_benchmark_test.go
+++ b/benchmarks/rename_benchmark_test.go
@@ -1,0 +1,43 @@
+package benchmarks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/farbodahm/streame/pkg/core"
+	. "github.com/farbodahm/streame/pkg/types"
+	"github.com/farbodahm/streame/pkg/utils"
+)
+
+// heavy_rename_column_stages renames a column
+// with lots of records
+func heavy_rename_column_stages(number_of_records int) {
+	input := make(chan Record)
+	output := make(chan Record)
+	errors := make(chan error)
+
+	sdf := core.NewStreamDataFrame(input, output, errors, utils.HeavyRecordSchema())
+
+	// Create stages
+	result_df := sdf.Rename("field_1", "new_field")
+
+	go func() {
+		for i := 0; i < number_of_records; i++ {
+			input <- utils.NewHeavyRecord(100)
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go result_df.Execute(ctx)
+
+	for i := 0; i < number_of_records; i++ {
+		<-output
+	}
+	cancel()
+}
+
+func BenchmarkRenameColumnFunction(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		heavy_rename_column_stages(3000)
+	}
+}

--- a/pkg/core/dataframe.go
+++ b/pkg/core/dataframe.go
@@ -12,6 +12,7 @@ type DataFrame interface {
 	Filter(filter functions.Filter) DataFrame
 	Select(columns ...string) DataFrame
 	AddStaticColumn(name string, value types.ColumnValue) DataFrame
+	Rename(old_name string, new_name string) DataFrame
 	Execute(ctx context.Context) error
 	GetSchema() types.Schema
 }

--- a/pkg/functions/rename_column.go
+++ b/pkg/functions/rename_column.go
@@ -1,0 +1,59 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/farbodahm/streame/pkg/types"
+)
+
+// RenameColumnInSchema renames the column in the schema.
+// It returns a new schema with the column renamed.
+func RenameColumnInSchema(schema types.Schema, old_column_name string, new_column_name string) (types.Schema, error) {
+	if _, exists := schema.Columns[old_column_name]; !exists {
+		return types.Schema{}, fmt.Errorf(ErrColumnNotFound, old_column_name)
+	}
+
+	if _, exists := schema.Columns[new_column_name]; exists {
+		return types.Schema{}, fmt.Errorf(ErrColumnAlreadyExists, new_column_name)
+	}
+
+	new_schema := types.Schema{Columns: types.Fields{}}
+	// Deep copy previous schema to new schema
+	// This is to ensure that the original schema is not modified
+	for key, value := range schema.Columns {
+		// Skip the column to be renamed
+		if key == old_column_name {
+			continue
+		}
+		new_schema.Columns[key] = value
+	}
+
+	// Rename column in new schema
+	new_schema.Columns[new_column_name] = schema.Columns[old_column_name]
+
+	return new_schema, nil
+}
+
+// RenameColumnInRecord renames the column in the record.
+// NOTE: As schema validation is forced on first stage,
+// this function doesn't check the schema of the record.
+// NOTE: This function does not add the column to the schema.
+// Caller needs to handle adding the column to the schema if needed.
+func RenameColumnInRecord(record types.Record, old_column_name string, new_column_name string) types.Record {
+	new_record := types.Record{
+		Key:      record.Key,
+		Metadata: record.Metadata,
+		Data:     types.ValueMap{},
+	}
+
+	// Deep copy previous record to new record
+	for key, value := range record.Data {
+		// Skip the column to be renamed
+		if key == old_column_name {
+			continue
+		}
+		new_record.Data[key] = value
+	}
+	new_record.Data[new_column_name] = record.Data[old_column_name]
+	return new_record
+}

--- a/pkg/functions/rename_column_test.go
+++ b/pkg/functions/rename_column_test.go
@@ -1,9 +1,11 @@
 package functions_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/farbodahm/streame/pkg/core"
 	"github.com/farbodahm/streame/pkg/functions"
 	. "github.com/farbodahm/streame/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -99,4 +101,151 @@ func TestRenameColumnInRecord_ValidName_ColumnIsRenamed(t *testing.T) {
 		"last_name":  String{Val: "random_lastname"},
 		"age":        Integer{Val: 10},
 	}, record.Data)
+}
+
+// Integration tests inside DataFrame
+func TestRename_ValidNames_ColumnIsRenamedInSchemaAndRecords(t *testing.T) {
+	input := make(chan Record)
+	output := make(chan Record)
+	errors := make(chan error)
+
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"age":        IntType,
+		},
+	}
+	sdf := core.NewStreamDataFrame(input, output, errors, schema)
+
+	// Logic to test
+	result_df := sdf.Rename("last_name", "family_name")
+
+	// Generate sample data
+	go func() {
+		records := []Record{
+			{
+				Key: "key1",
+				Data: ValueMap{
+					"first_name": String{Val: "random_name"},
+					"last_name":  String{Val: "random_lastname"},
+					"age":        Integer{Val: 10},
+				},
+			},
+			{
+				Key: "key2",
+				Data: ValueMap{
+					"first_name": String{Val: "foobar"},
+					"last_name":  String{Val: "random_lastname"},
+					"age":        Integer{Val: 20},
+				},
+			},
+			{
+				Key: "key3",
+				Data: ValueMap{
+					"first_name": String{Val: "random_name2"},
+					"last_name":  String{Val: "random_lastname2"},
+					"age":        Integer{Val: 30},
+				},
+			},
+		}
+		for _, record := range records {
+			input <- record
+		}
+	}()
+
+	ctx := context.Background()
+	go result_df.Execute(ctx)
+
+	// Assertions
+	expected_records := []Record{
+		{
+			Key: "key1",
+			Data: ValueMap{
+				"first_name":  String{Val: "random_name"},
+				"family_name": String{Val: "random_lastname"},
+				"age":         Integer{Val: 10},
+			},
+		},
+		{
+			Key: "key2",
+			Data: ValueMap{
+				"first_name":  String{Val: "foobar"},
+				"family_name": String{Val: "random_lastname"},
+				"age":         Integer{Val: 20},
+			},
+		},
+		{
+			Key: "key3",
+			Data: ValueMap{
+				"first_name":  String{Val: "random_name2"},
+				"family_name": String{Val: "random_lastname2"},
+				"age":         Integer{Val: 30},
+			},
+		},
+	}
+
+	for _, expected_record := range expected_records {
+		result := <-output
+		assert.Equal(t, expected_record, result)
+	}
+	ctx.Done()
+	assert.Equal(t, 0, len(output))
+	assert.Equal(t, 0, len(sdf.ErrorStream))
+	assert.Equal(t, 0, len(errors))
+	assert.Equal(t, Schema{
+		Columns: Fields{
+			"first_name":  StringType,
+			"family_name": StringType,
+			"age":         IntType,
+		},
+	}, result_df.GetSchema())
+	// Assert that renaming column did not modify the original schema
+	assert.Equal(t, schema, sdf.GetSchema())
+}
+
+func TestRename_AddAlreadyExistingColumn_PanicsWithAlreadyExistsColumn(t *testing.T) {
+	input := make(chan Record)
+	output := make(chan Record)
+	errors := make(chan error)
+
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"age":        IntType,
+		},
+	}
+	sdf := core.NewStreamDataFrame(input, output, errors, schema)
+
+	assert.Panicsf(t,
+		func() {
+			sdf.Rename("last_name", "first_name")
+		},
+		functions.ErrColumnAlreadyExists,
+		"first_name",
+	)
+}
+
+func TestRename_AddColumnNameNotExists_PanicsWithColumnNotFound(t *testing.T) {
+	input := make(chan Record)
+	output := make(chan Record)
+	errors := make(chan error)
+
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"age":        IntType,
+		},
+	}
+	sdf := core.NewStreamDataFrame(input, output, errors, schema)
+
+	assert.Panicsf(t,
+		func() {
+			sdf.Rename("random_name", "first_name")
+		},
+		functions.ErrColumnNotFound,
+		"random_name",
+	)
 }

--- a/pkg/functions/rename_column_test.go
+++ b/pkg/functions/rename_column_test.go
@@ -1,0 +1,102 @@
+package functions_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/farbodahm/streame/pkg/functions"
+	. "github.com/farbodahm/streame/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenameColumnInSchema_ValidColumnName_ColumnIsRenamedInSchema(t *testing.T) {
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"age":        IntType,
+		},
+	}
+	expected_schema := Schema{
+		Columns: Fields{
+			"first_name":  StringType,
+			"family_name": StringType,
+			"age":         IntType,
+		},
+	}
+
+	actual_schema, err := functions.RenameColumnInSchema(schema, "last_name", "family_name")
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected_schema, actual_schema)
+	// Assert renaming column did not modify the original schema
+	assert.Equal(t, Fields{
+		"first_name": StringType,
+		"last_name":  StringType,
+		"age":        IntType,
+	}, schema.Columns)
+}
+
+func TestRenameColumnInSchema_NewColumnNameExists_ReturnColumnAlreadyExistsError(t *testing.T) {
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"age":        IntType,
+		},
+	}
+
+	actual_schema, err := functions.RenameColumnInSchema(schema, "last_name", "first_name")
+
+	expected_error := fmt.Sprintf(functions.ErrColumnAlreadyExists, "first_name")
+
+	assert.EqualError(t, err, expected_error)
+	assert.Equal(t, Schema{}, actual_schema)
+}
+
+func TestRenameColumnInSchema_OldColumnDoesntExists_ReturnColumnNotFoundError(t *testing.T) {
+	schema := Schema{
+		Columns: Fields{
+			"first_name": StringType,
+			"last_name":  StringType,
+			"age":        IntType,
+		},
+	}
+
+	actual_schema, err := functions.RenameColumnInSchema(schema, "random_name", "some_name")
+
+	expected_error := fmt.Sprintf(functions.ErrColumnNotFound, "random_name")
+
+	assert.EqualError(t, err, expected_error)
+	assert.Equal(t, Schema{}, actual_schema)
+}
+
+func TestRenameColumnInRecord_ValidName_ColumnIsRenamed(t *testing.T) {
+	record := Record{
+		Key: "key1",
+		Data: ValueMap{
+			"first_name": String{Val: "foobar"},
+			"last_name":  String{Val: "random_lastname"},
+			"age":        Integer{Val: 10},
+		},
+	}
+	expected_result := Record{
+		Key: "key1",
+		Data: ValueMap{
+			"first_name":  String{Val: "foobar"},
+			"family_name": String{Val: "random_lastname"},
+			"age":         Integer{Val: 10},
+		},
+	}
+
+	actual_result := functions.RenameColumnInRecord(record, "last_name", "family_name")
+
+	assert.Equal(t, expected_result, actual_result)
+	// Assert that input record is not modified
+	assert.Equal(t, "key1", record.Key)
+	assert.Equal(t, ValueMap{
+		"first_name": String{Val: "foobar"},
+		"last_name":  String{Val: "random_lastname"},
+		"age":        Integer{Val: 10},
+	}, record.Data)
+}


### PR DESCRIPTION
This PR:
- Adds functions for renaming a column in schema and records & add unit tests
- Integrates the functionality to main dataframe and add integration tests
- Add benchmark tests

Closes #22 . 