### PR TITLE
fix: cancelling the context with proper cancel function

### DIFF
--- a/pkg/functions/add_column_test.go
+++ b/pkg/functions/add_column_test.go
@@ -130,7 +130,7 @@ func TestAddStaticColumn_AddIntegerField_AddColumnToSchemaAndRecords(t *testing.
 		}
 	}()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	go result_df.Execute(ctx)
 
 	// Assertions
@@ -165,7 +165,7 @@ func TestAddStaticColumn_AddIntegerField_AddColumnToSchemaAndRecords(t *testing.
 		result := <-output
 		assert.Equal(t, expected_record, result)
 	}
-	ctx.Done()
+	cancel()
 	assert.Equal(t, 0, len(output))
 	assert.Equal(t, 0, len(sdf.ErrorStream))
 	assert.Equal(t, 0, len(errors))

--- a/pkg/functions/filter_test.go
+++ b/pkg/functions/filter_test.go
@@ -131,12 +131,12 @@ func TestFilter_WithDataFrame_AcceptRelatedRecord(t *testing.T) {
 		}
 	}()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	go result_df.Execute(ctx)
 
 	// Assertions
-	ctx.Done()
 	result := <-output
+	cancel()
 	assert.Equal(t, result, accepted_record)
 	assert.Equal(t, 0, len(output))
 	assert.Equal(t, 0, len(sdf.ErrorStream))
@@ -200,12 +200,12 @@ func TestFilter_WithChainedDataFrame_AcceptRelatedRecord(t *testing.T) {
 		}
 	}()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	go result_df.Execute(ctx)
 
 	// Assertions
-	ctx.Done()
 	result := <-output
+	cancel()
 	assert.Equal(t, result, accepted_record)
 	assert.Equal(t, 0, len(output))
 	assert.Equal(t, 0, len(sdf.ErrorStream))

--- a/pkg/functions/rename_column_test.go
+++ b/pkg/functions/rename_column_test.go
@@ -154,7 +154,7 @@ func TestRename_ValidNames_ColumnIsRenamedInSchemaAndRecords(t *testing.T) {
 		}
 	}()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	go result_df.Execute(ctx)
 
 	// Assertions
@@ -189,7 +189,7 @@ func TestRename_ValidNames_ColumnIsRenamedInSchemaAndRecords(t *testing.T) {
 		result := <-output
 		assert.Equal(t, expected_record, result)
 	}
-	ctx.Done()
+	cancel()
 	assert.Equal(t, 0, len(output))
 	assert.Equal(t, 0, len(sdf.ErrorStream))
 	assert.Equal(t, 0, len(errors))

--- a/pkg/functions/schema_validator_test.go
+++ b/pkg/functions/schema_validator_test.go
@@ -157,14 +157,14 @@ func TestSreamDataFrame_SchemaValidation_AcceptRecordFollowSchema(t *testing.T) 
 		input <- record_2
 	}()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	go sdf.Execute(ctx)
 
-	ctx.Done()
 	result_1 := <-output
 	result_2 := <-output
 
 	// Assertions
+	cancel()
 	assert.Equal(t, result_1.Key, "key1")
 	assert.Equal(t, result_2.Key, "key2")
 	assert.Equal(t, 0, len(errors))

--- a/pkg/functions/select_test.go
+++ b/pkg/functions/select_test.go
@@ -129,7 +129,7 @@ func TestSelect_WithDataFrame_SelectOnlyExpectedFields(t *testing.T) {
 		}
 	}()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	go result_df.Execute(ctx)
 
 	// Assertions
@@ -161,7 +161,7 @@ func TestSelect_WithDataFrame_SelectOnlyExpectedFields(t *testing.T) {
 		result := <-output
 		assert.Equal(t, expected_record, result)
 	}
-	ctx.Done()
+	cancel()
 	assert.Equal(t, 0, len(output))
 	assert.Equal(t, 0, len(sdf.ErrorStream))
 	assert.Equal(t, 0, len(errors))


### PR DESCRIPTION
Apparently my Copilot was calling `ctx.Done()` instead of `cancel()` function while auto completing the tests :))